### PR TITLE
Fix incorrect bool cast in existsValidToken

### DIFF
--- a/src/PassportToken.php
+++ b/src/PassportToken.php
@@ -77,7 +77,7 @@ class PassportToken
                 ->where('id', $token_id)
                 ->where('user_id', $user_id)
                 ->where('expires_at', '>=', date('Y-m-d H:i:s'))
-                ->get();
+                ->count();
         } else {
             return false;
         }


### PR DESCRIPTION
The `existsValidToken` always returns `true` as it tries to cast the result of `DB::get()` to a `bool`.

This PR simply changes the `DB::get()` to `DB::count()` before the cast, which fixes the problem